### PR TITLE
Use alternate serviceaccount to verify route connectivity

### DIFF
--- a/tests/interop/test_validate_hub_site_components.py
+++ b/tests/interop/test_validate_hub_site_components.py
@@ -218,9 +218,7 @@ def test_validate_argocd_reachable_hub_site(openshift_dyn_client):
         sub_string="argocd-dex-server-token",
     )
     if not bearer_token:
-        err_msg = (
-            "Bearer token is missing for argocd-dex-server"
-        )
+        err_msg = "Bearer token is missing for argocd-dex-server"
         logger.error(f"FAIL: {err_msg}")
         assert False, err_msg
     else:

--- a/tests/interop/test_validate_hub_site_components.py
+++ b/tests/interop/test_validate_hub_site_components.py
@@ -56,9 +56,14 @@ def test_validate_hub_site_reachable(kube_config, openshift_dyn_client):
     else:
         logger.info(f"HUB api url : {hub_api_url}")
 
-    bearer_token = get_long_live_bearer_token(dyn_client=openshift_dyn_client)
+    bearer_token = get_long_live_bearer_token(
+        dyn_client=openshift_dyn_client,
+        namespace="openshift-gitops",
+        sub_string="argocd-dex-server-token",
+    )
+
     if not bearer_token:
-        assert False, "Bearer token is missing for hub site"
+        assert False, "Bearer token is missing for argocd-dex-server"
 
     hub_api_response = get_site_response(
         site_url=hub_api_url, bearer_token=bearer_token
@@ -210,11 +215,11 @@ def test_validate_argocd_reachable_hub_site(openshift_dyn_client):
     bearer_token = get_long_live_bearer_token(
         dyn_client=openshift_dyn_client,
         namespace=namespace,
-        sub_string="openshift-gitops-argocd-server-token",
+        sub_string="argocd-dex-server-token",
     )
     if not bearer_token:
         err_msg = (
-            "Bearer token is missing for argocd-server in openshift-gitops" " namespace"
+            "Bearer token is missing for argocd-dex-server"
         )
         logger.error(f"FAIL: {err_msg}")
         assert False, err_msg


### PR DESCRIPTION
In Openshift 4.16, many serviceaccounts/tokens seem to have been removed, including 2 we were using to verify routes.
"argocd-dex-server-token" works for all route checks.