### PR TITLE
Switch to ODF 0.2.x

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -58,7 +58,7 @@ clusterGroup:
       namespace: openshift-storage
       project: medical-diagnosis
       chart: openshift-data-foundations
-      chartVersion: 0.1.*
+      chartVersion: 0.2.*
 
     openshift-serverless:
       name: serverless


### PR DESCRIPTION
Already done for IE, let's do it here as well so the defaults are bit
friendlier due to the host failureDomain (i.e. ODF will work also on
clusters with nodes all on the same AZ)
