### PR TITLE
pin amq-streams operator subscription to channel that supports zookeeper

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -21,6 +21,7 @@ clusterGroup:
     amq-streams:
       name: amq-streams
       namespace: xraylab-1
+      channel: amq-streams-2.9.x
 
     grafana:
       name: grafana-operator


### PR DESCRIPTION
This pattern is currently broken since amq-streams 3.0+ remove support for zookeeper entirely in favor of KRaft. Thus, this PR pins the channel to the latest one to offer zookeeper support. long-term, we'll want to migrate to KRaft but in the meantime this will fix installations of this pattern