### PR TITLE
disable storageSystem deployment

### DIFF
--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -60,6 +60,10 @@ clusterGroup:
       project: medical-diagnosis
       chart: openshift-data-foundations
       chartVersion: 0.2.*
+      overrides:
+        - name: storageSystem.deploy
+          value: 'false'
+
 
     openshift-serverless:
       name: serverless

--- a/values-hub.yaml
+++ b/values-hub.yaml
@@ -1,5 +1,4 @@
 storageSystem:
-  deploy: true
   inventory:
     useSpecificNodes: false
 
@@ -60,10 +59,6 @@ clusterGroup:
       project: medical-diagnosis
       chart: openshift-data-foundations
       chartVersion: 0.2.*
-      overrides:
-        - name: storageSystem.deploy
-          value: 'false'
-
 
     openshift-serverless:
       name: serverless


### PR DESCRIPTION
ODF 4.19 doesn't support the storageSystem api resource any more. However, older releases of ODF do. If depoying the pattern on an older release of OpenShift and requiring the storageSystem resource it can be overriden in values-hub.yaml.
